### PR TITLE
Utilize GH token for increased API access

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,7 @@ config :lowendinsight_get,
   cache_ttl: String.to_integer(System.get_env("LEI_CACHE_TTL") || "30"),
   cache_clean_enable: String.to_atom(System.get_env("LEI_CACHE_CLEAN_ENABLE") || "true"),
   check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true"),
+  gh_token: System.get_env("LEI_GH_TOKEN") || "",
   languages: [
     "elixir",
     "python",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,8 @@
 use Mix.Config
 
 config :lowendinsight_get,
-  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "false")
+  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "false"),
+  gh_token: System.get_env("LEI_GH_TOKEN") || ""
 
 config :redix,
   redis_url: System.get_env("REDIS_URL") || "redis://localhost:6379/3"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,7 +11,8 @@ config :lowendinsight_get, LowendinsightGet.Endpoint,
   port: String.to_integer(System.get_env("PORT") || "4444")
 
 config :lowendinsight_get, 
-  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true")
+  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true"),
+  gh_token: System.get_env("LEI_GH_TOKEN") || ""
 
 config :lowendinsight,
   ## Contributor in terms of discrete users

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,7 +12,8 @@ config :lowendinsight_get, LowendinsightGet.Endpoint, port: 4444
 config :lowendinsight_get,
   cache_ttl: String.to_integer(System.get_env("LEI_CACHE_TTL") || "30"),
   cache_clean_enable: String.to_atom(System.get_env("LEI_CACHE_CLEAN_ENABLE") || "true"),
-  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true")
+  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true"),
+  gh_token: System.get_env("LEI_GH_TOKEN") || ""
 
 config :lowendinsight,
   ## Contributor in terms of discrete users

--- a/lib/lowendinsight_get/github_trending.ex
+++ b/lib/lowendinsight_get/github_trending.ex
@@ -59,7 +59,6 @@ defmodule LowendinsightGet.GithubTrending do
               "metadata" => %{"times" => %{}},
               "report" => %{"uuid" => UUID.uuid1(), "repos" => []}
             }
-
           _ ->
             {:ok, report_json} = Redix.command(:redix, ["GET", uuid])
             Poison.Parser.parse!(report_json)
@@ -67,15 +66,25 @@ defmodule LowendinsightGet.GithubTrending do
     end
   end
 
+  defp get_token() do
+    if Application.fetch_env(:lowendinsight_get, :gh_token) == :error,
+    do: "",
+    else: Application.fetch_env!(:lowendinsight_get, :gh_token)
+  end
+
+  defp fetch_gh_api_response(token, slug) do
+    headers = ["Authorization": "Bearer #{token}", "Accept": "Application/json; Charset=utf-8"]
+    HTTPoison.get("https://api.github.com/repos/" <> slug, headers)
+  end
+
   def get_repo_size(url) do
     case Helpers.get_slug(url) do
       {:ok, slug} -> 
-        {:ok, response} = HTTPoison.get("https://api.github.com/repos/" <> slug)
+        {:ok, response} = fetch_gh_api_response(get_token(), slug)
         json = Poison.Parser.parse!(response.body)
         {json["size"], url}
       {:error, msg} -> {:error, msg}
     end
-
   end
 
   def filter_out_large_repos({repo_size, url}, check_repo?) when repo_size < 1000000 or not check_repo? do

--- a/rel/config/prod.exs
+++ b/rel/config/prod.exs
@@ -9,7 +9,8 @@ config :lowendinsight_get, LowendinsightGet.Endpoint, port: String.to_integer(Sy
 config :lowendinsight_get,
   cache_ttl: String.to_integer(System.get_env("LEI_CACHE_TTL") || "30"),
   cache_clean_enable: String.to_atom(System.get_env("LEI_CACHE_CLEAN_ENABLE") || "true"),
-  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true")
+  check_repo_size?: String.to_atom(System.get_env("LEI_CHECK_REPO_SIZE") || "true"),
+  gh_token: System.get_env("LEI_GH_TOKEN") || ""
 
 config :lowendinsight,
   ## Contributor in terms of discrete users

--- a/test/lowendinsight_get/cache_cleaner_test.exs
+++ b/test/lowendinsight_get/cache_cleaner_test.exs
@@ -22,10 +22,12 @@ defmodule LowendinsightGet.CacheCleanerTest do
     {:ok, conn} = Redix.start_link(Application.get_env(:redix, :redis_url))
     case Redix.command(conn, ["KEYS", "http*"]) do
       {:ok, _keys} ->
-        {:ok, nil} = Redix.command(conn, ["GET", "fake_key"])
-        {:ok, json} = Redix.command(conn, ["GET", elixir_url])
-        value = Poison.decode!(json)
-        assert value["header"]["end_time"] != nil
+        assert {:ok, nil} == Redix.command(conn, ["GET", "fake_key"])
+        case Redix.command(conn, ["GET", elixir_url]) do
+          {:ok, json} ->
+            value = Poison.decode!(json)
+            assert value["header"]["end_time"] != nil
+        end
     end
     Redix.stop(conn)
   end

--- a/test/lowendinsight_get/cache_cleaner_test.exs
+++ b/test/lowendinsight_get/cache_cleaner_test.exs
@@ -20,6 +20,7 @@ defmodule LowendinsightGet.CacheCleanerTest do
     elixir_url = "https://github.com/elixir-lang/elixir"
     {:ok, _report} = LowendinsightGet.Analysis.analyze(elixir_url, "lei-get", %{types: false})
     {:ok, conn} = Redix.start_link(Application.get_env(:redix, :redis_url))
+    
     case Redix.command(conn, ["KEYS", "http*"]) do
       {:ok, _keys} ->
         assert {:ok, nil} == Redix.command(conn, ["GET", "fake_key"])


### PR DESCRIPTION
...needed to allow for more repo size requests from API, to prevent downloading VL source repos in Heroku