### PR TITLE
newer erlang version for heroku buildpack

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
-erlang_version=24.0
+erlang_version=24.0.1
 elixir_version=1.12.0


### PR DESCRIPTION
Trying to install Erlang OTP 24.0.1 in Heroku buildpack